### PR TITLE
Use MAP_FAILED to validate the result of mmap(2)

### DIFF
--- a/nloc.c
+++ b/nloc.c
@@ -110,7 +110,7 @@ void countComments( int fp , size_t *totalLines, size_t *single, size_t *multi )
   off_t size = stats.st_size;
   if(size < 1) return;
   unsigned char * f = mmap(NULL, size, PROT_READ, MAP_PRIVATE | MAP_POPULATE, fp, 0);
-  if(f == NULL) return;
+  if(f == MAP_FAILED) return;
 
   while ( pos <  size )
   {


### PR DESCRIPTION
The mmap(2) returns not a NULL, but the said constant in case of error.
The constant has usually not a 0, but an integer -1 value.